### PR TITLE
Fix TV window calculations based on image width

### DIFF
--- a/assets/components/imageplus/mgr/js/imageplus.panel.input.js
+++ b/assets/components/imageplus/mgr/js/imageplus.panel.input.js
@@ -344,12 +344,15 @@ Ext.extend(ImagePlus.panel.input, MODx.Panel, {
             var imgW = this.imageplus.sourceImg.width;
             var imgH = this.imageplus.sourceImg.height;
             var maxH = window.innerHeight * 0.7;
-            var maxW = window.innerWidth * 0.7;
+            var maxW = window.innerWidth * 0.9;
             var ratio;
 
             // Is image taller than screen?
             if (imgH > maxH) {
                 ratio = maxH / imgH
+                if ((imgW*ratio) > maxW) {
+                    ratio = maxW / imgW
+                }
             } else {
                 if (imgW > maxW) {
                     ratio = maxW / imgW


### PR DESCRIPTION
Now checks image width as well as height before plotting the window. Previously if the height was adjusted, no width was checking which allowed images with a certain ratio to go outside the edges of the browser window. I also increased the possible width of the window to 90% of the browser window as 70% seemed to waste a fair bit of screen space.