### PR TITLE
Removed file format and quality.

### DIFF
--- a/assets/components/imageplus/mgr/js/imageplus.js
+++ b/assets/components/imageplus/mgr/js/imageplus.js
@@ -38,8 +38,6 @@ Ext.extend(imagePlus, Ext.Component, {
         var url = MODx.config.connectors_url + 'system/phpthumb.php?imageplus=1';
         var defaults = {
             wctx: 'mgr',
-            f: 'png',
-            q: 90,
             w: 150,
             source: 1
         };


### PR DESCRIPTION
The fixed png file format is not good at this point, as fotos result in PNG files then. Pthumb automatically choose the right format depending on the source format. So if you don't set it here, JPG fotos will be generated as JPG thumbs. 
Also the quality settings should use the default settings from system settings.
Addition: would be better to have a configurable system setting to manage individual output format here. Might also be possible at TV level to control how the TV is displayed in manager.