### PR TITLE
empty image url by default

### DIFF
--- a/core/components/imageplus/model/cropengines/PhpThumbOf.php
+++ b/core/components/imageplus/model/cropengines/PhpThumbOf.php
@@ -138,7 +138,8 @@ class PhpThumbOf extends AbstractCropEngine
                     )
                 );
             } else {
-                $url = '';
+                $sourceBases = $source->getBases();
+                $url = $sourceBases[url] . $data->sourceImg->src;
             }
         } else {
             $url = $data->sourceImg->src;


### PR DESCRIPTION
If you select Image+ as output type of the tv and leave the default option "generate Thumbnail URL" to false (by default): you receive an empty url.
I think this will fix it?