### PR TITLE
Prevent error if $modx->resource is not set

### DIFF
--- a/core/components/imageplus/elements/snippets/imageplus.snippet.php
+++ b/core/components/imageplus/elements/snippets/imageplus.snippet.php
@@ -24,7 +24,14 @@ $imageplus = $modx->getService('imageplus', 'ImagePlus', $corePath . 'model/imag
 ));
 
 $tvname = $modx->getOption('tvname', $scriptProperties, '', true);
-$docid = $modx->getOption('docid', $scriptProperties, $modx->resource->get('id'), true);
+$docid = $modx->getOption('docid', $scriptProperties, '', true);
+if ( '' === $docid ) {
+    if ( ! isset( $modx->resource ) ) {
+        $modx->log(xPDO::LOG_LEVEL_ERROR, 'Unable to determine the ID of the current resource.', '', 'Image+');
+        return 'Unable to determine the ID of the current resource.';
+    }
+    $docid = $modx->resource->get('id');
+}
 $type = $modx->getOption('type', $scriptProperties, '', true);
 $options = $modx->getOption('options', $scriptProperties, '', true);
 $tpl = $modx->getOption('tpl', $scriptProperties, 'ImagePlus.image', true);


### PR DESCRIPTION
The ImagePlus snippet causes a FATAL ERROR if `$modx->resource` is not set, even if the &docid property is provided explicitly.

The snippet should only try to call `$modx->resource->get('id')` if the &docid property is NOT provided.

In normal circumstances this does not cause an issue, as `$modx->resource->get('id')` would succeed, but for example when the snippet is used from within a call to `assets/components/migx/connector.php` `$modx->resource` may be null, and in those cases `$modx->resource->get('id')` results in `Fatal error: Uncaught Error: Call to a member function get() on null` in line 27.

This is in fact a real issue when trying to use `[[ImagePlus...` in a MIGX a render chunk. For detailed analysis see here: https://github.com/Bruno17/MIGX/issues/354