### PR TITLE
Update Markdown

### DIFF
--- a/core/components/imageplus/docs/changelog.md
+++ b/core/components/imageplus/docs/changelog.md
@@ -1,124 +1,184 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.8.2] - 2021-01-19
+
 ### Changed
+
 - Fix the ImagePlus.MIGX_Renderer to show normal images too
 
 ## [2.8.1] - 2020-01-04
+
 ### Changed
+
 - Prevent an error, when $modx->resource is not set
 
 ## [2.8.0] - 2018-11-15
+
 ### Changed
+
 - Updated jQuery
 - Fixing a jQuery issue with ContentBlocks and other extras that use jQuery inside [#60]
 - Fixing cannot read property 'destroy' of undefined issue
 - Fixing Undefined property issue [#71]
 - Fixing a window issue with really small images [#53]
+
 ### Removed
+
 - Some IE < 9 CSS rules
 
 ## [2.7.0] - 2017-11-13
+
 ### Changed
+
 - Bugfix for using a wrong plugin event name in special circumstances
 - Improved check for the allowBlank TV option
+
 ### Added
+
 - phpThumbOn crop engine
 - Warning in the TV output options for the right usage of the Generate Thumb URL property
 
 ## [2.6.3] - 2017-06-01
+
 ### Changed
+
 - Bugfix a full server path in the url placeholder
 
 ## [2.6.2] - 2017-02-21
+
 ### Changed
+
 - Bugfix for disabled option 'Generate Thumbnail URL' and an empty url placeholder
 
 ## [2.6.1] - 2017-02-03
+
 ### Changed
+
 - Bugfix for an empty select_config system setting
 
 ## [2.6.0] - 2017-02-01
+
 ### Changed
+
 - Fixed a missing realpath issue
+
 ### Added
+
 - System wide predefined crop sizes/aspect ratios, selectable in the TV options
 - Context/system settings that supercede the TV options
+
 ### Removed
+
 - MODX 2.2 compatibility
 
 ## [2.5.0] - 2016-12-17
+
 ### Changed
+
 - Fix showing a full server path, when the image is not found [#41]
+
 ### Added
+
 - Optional caption and credits fields below of the image
 
 ## [2.4.5] - 2016-07-29
+
 ### Changed
+
 - Solved an installation issue on Windows machines
 
 ## [2.4.4] - 2016-06-15
+
 ### Changed
+
 - Don't try get an Image+ url with an empty template variable value
 - Change the image by typing the filename
 - Correcting typos, refactored code
+
 ### Added
+
 - Add assets files on manager pages (i.e. for MIGX)
 - Log invalid JSON only if imageplus.debug system setting is active
 - Use only uglified/minified scripts in package code
 
 ## [2.4.3] - 2016-03-03
+
 ### Changed
+
 - Fixed not found image in combined/minified css file
+
 ### Added
+
 - The alt text field could contain special chars
 - Debug system setting for enabling not combined and minified/uglified css/js files
 
 ## [2.4.2] - 2016-01-18
+
 ### Added
+
 - The snippet could use inherited values
 
 ## [2.4.1] - 2016-01-16
+
 ### Changed
+
 - Change the image by typing the filename
+
 ### Added
+
 - Fixing recoverable errors
 - Translated error messages
 
 ## [2.4.0] - 2016-01-15
+
 ### Changed
+
 - Improved error logging
 - Resolved issues with apostrophes in language strings
+
 ### Added
+
 - Retain the value of a MODX TV as source image for the Image+ TV
 - Fill output chunk placeholders with script properties
 
 ## [2.3.4] - 2015-08-06
+
 ### Changed
+
 - Open crop window automatic after selecting a new image
 - Bugfix for media source issue in MIGX
 
 ## [2.3.3] - 2015-07-05
+
 ### Changed
+
 - Run jQuery in noConflict mode
 
 ## [2.3.2] - 2015-06-06
+
 ### Added
+
 - 'value' parameter in the ImagePlus Snippet
 
 ## [2.3.1] - 2015-06-05
+
 ### Changed
+
 - Use default_media_source if the media source of the TV is not set (i.e. if it used in a MIGX configuration)
 - Don't show the crop window if the image size is invalid
+
 ### Added
+
 - Enable property sets for the ImagePlus Snippet
 
 ## [2.3.0] - 2015-05-24
+
 ### Changed
+
 - Bugfix for fireResourceFormChange issue
 - Updated Jcrop plugin and jQuery
 - Bugfix for a Firefox display issue
@@ -126,7 +186,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated Dutch translation (@Mark-H)
 - Updated French translation (@AmaZili)
 - Updated Russian translation (@Alroniks, serimarda)
+
 ### Added
+
 - MODX 2.3 compatibility
 - Inline Trigger fields
 - Some better backend styling
@@ -136,13 +198,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Center the crop window in the viewport
 
 ## [2.2.x] - 2013-11-02
+
 ### Changed
+
 - Refactored to allow changing of crop engines
 - Confirmed to work with Articles [#21]
 - Now works with MIGX [#15]
 - TV Default Value is now output if TV is empty
 - TV Reset button now works [#22]
+
 ### Added
+
 - GUI warning of missing dependencies
 - phpThumbsUp crop engine
 - grid renderer for MIGX backend
@@ -162,12 +228,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - French translation (@Alroniks)
 
 ## [2.1.x] - 2012-12-09
+
 ### Changed
+
 - Fixed bug with non-default media sources
+
 ### Added
+
 - Field for additional phpThumb parameters to output renderer
 - Option to specify a chunk for output formatting (fields: url,alt,width,height)
 
 ## [2.0.x] - 2012-12-01
+
 ### Added
+
 - Complete rewrite

--- a/core/components/imageplus/docs/readme.md
+++ b/core/components/imageplus/docs/readme.md
@@ -8,11 +8,8 @@ Advanced image custom template variable for MODX Revolution.
 
 ## Features
 
-With this MODX Revolution custom template variable an image could be cropped
-while maintaining the original image. The dimensions for the image can
-(optionally) be configured to constrain a minimal width and/or height. The image
-crop could be forced to remain at a pre-set ratio. A graphical tool could be
-used to crop the image to the required dimensions/proportions.
+With this MODX Revolution custom template variable an image could be cropped while maintaining the original image. The dimensions for the image can
+(optionally) be configured to constrain a minimal width and/or height. The image crop could be forced to remain at a pre-set ratio. A graphical tool could be used to crop the image to the required dimensions/proportions.
 
 ## Installation
 
@@ -20,17 +17,15 @@ MODX Package Management
 
 ## Usage
 
-Install via package manager, create a TV and change the input & output type to
-'Image+'
+Install via package manager, create a TV and change the input & output type to 'Image+'
 
 ## Documentation
 
-For more information please read the documentation on
-https://jako.github.io/ImagePlus/
+For more information please read the documentation on <https://jako.github.io/ImagePlus/>
 
 ## GitHub Repository
 
-https://github.com/Jako/ImagePlus
+<https://github.com/Jako/ImagePlus>
 
 ## Dependencies
 

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -1,6 +1,4 @@
-The Image+ project was started in 2012 by [Alan
-Pich](https://github.com/alanpich) and is maintained and developed further since
-2015 by [Thomas Jakobi](https://github.com/jako).
+The Image+ project was started in 2012 by [AlanPich](https://github.com/alanpich) and is maintained and developed further since 2015 by [Thomas Jakobi](https://github.com/jako).
 
 Many thanks to everyone else, who has contributed to this project:
 

--- a/docs/donate.md
+++ b/docs/donate.md
@@ -1,11 +1,8 @@
-## Support Image+
+# Support Image+
 
-*Image+* is and always will be free and open-source, but it still requires many
-man-hours of development, bug-fixing, support in MODX forums and on GitHub
-between the releases.
+*Image+* is and always will be free and open-source, but it still requires many man-hours of development, bug-fixing, support in MODX forums and on GitHub between the releases.
 
-Please support the ongoing and past development of *Image+* by making a donation
-below.
+Please support the ongoing and past development of *Image+* by making a donation below.
 
 <!-- Donation to Thomas Jakobi for MODX Open Source Extra -->
 <div style="margin-bottom: 2em">

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,18 +1,14 @@
-**Image+* could be used for several purposes. On this page you find some
-*examples how to use it:
+**Image+* could be used for several purposes. On this page you find some *examples how to use it:
 
-### Collections
+## Collections
 
-You could show the *Image+* thumbnail in a Collections grid column by setting
-the column renderer to *ImagePlus.MIGX_Renderer*.
+You could show the *Image+* thumbnail in a Collections grid column by setting the column renderer to *ImagePlus.MIGX_Renderer*.
 
-### MIGX
+## MIGX
 
-If you want to use *Image+* in MIGX you could define all *Image+* TV properties
-with a JSON string in the *Configs* textarea in the MIGX formtabs field
-configuration. The following properties are possible:
+If you want to use *Image+* in MIGX you could define all *Image+* TV properties with a JSON string in the *Configs* textarea in the MIGX formtabs field configuration. The following properties are possible:
 
-```
+``` json
 {
 "targetWidth":"",
 "targetHeight":"",
@@ -26,52 +22,44 @@ configuration. The following properties are possible:
 
 And you also have to change the *Input TV Type* to `imageplus`.
 
-You could show the thumbnail in the grid column by setting the renderer to
-*ImagePlus.MIGX_Renderer*. In prior MIGX versions you have to raw edit a MIGX
-configuration for that.
+You could show the thumbnail in the grid column by setting the renderer to *ImagePlus.MIGX_Renderer*. In prior MIGX versions you have to raw edit a MIGX configuration for that.
 
-To use that *Image+*-MIGX-Field in the Frontend, call the *ImagePlus Snippet*
-with just the value-parameter being the name of this MIGX-Field:
+To use that *Image+*-MIGX-Field in the Frontend, call the *ImagePlus Snippet* with just the value-parameter being the name of this MIGX-Field:
 
-```
+``` php
 [[ImagePlus? 
   &value=`[[+migxImagePlusField]]`
 ]]
 ```
 
-This will get you the prepared URL for the cropped image, instead of the raw
-JSON-Object.
+This will get you the prepared URL for the cropped image, instead of the raw JSON-Object.
 
-### getResources/pdoResources
+## getResources/pdoResources
 
-In order for the TV to be parsed with the *getResources/pdoResources Snippet*,
-make sure you add the following lines to your *getResources/pdoResources
-Snippet* call:
+In order for the TV to be parsed with the *getResources/pdoResources Snippet*, make sure you add the following lines to your *getResources/pdoResources Snippet* call:
 
-```
+``` php
 &includeTVs=`name_of_your_tv`
 &processTVs=`name_of_your_tv`
 ```
 
-In the template Chunk of the *getResources/pdoResources Snippet* call you
-could use the placeholder `[[+tv.name_of_your_tv]]` if the Output Type of the TV
-is set to `Image+`. Without additional changes, the placeholder contains the url
-to the cropped image.
+In the template Chunk of the *getResources/pdoResources Snippet* call you could use the placeholder `[[+tv.name_of_your_tv]]` if the Output Type of the TV is set to `Image+`. Without additional changes, the placeholder contains the url to the cropped image.
 
-### Using the ImagePlus Snippet inside getResources/pdoResources Template Chunk
+## Using the ImagePlus Snippet inside getResources/pdoResources Template Chunk
 
 In your template Chunk for *getResources/pdoResources Snippet* call, you need
 to add one parameter so that the *ImagePlus Snippet* call knows the origin ID to
 pull data from:
 
-```
- &docid=`[[+id]]`
+``` php
+&docid=`[[+id]]`
 ```
 
 Here is an example call and configuration, where *image* is your Image+ TV:
 
 **Snippet Call**
-```
+
+``` php
 <div class="blog-articles">
 [[!pdoPage?
     &element=`pdoResources`
@@ -89,7 +77,7 @@ Here is an example call and configuration, where *image* is your Image+ TV:
 
 **Chunk tplBlogPost**
 
-```
+``` html
 <article class="post">
     <header class="post-header">
         <h3 class="post-title mt0 mb1"><a href="[[~[[+id]]]]">[[+longtitle:default=`[[+pagetitle]]`]]</a></h3>
@@ -115,7 +103,7 @@ Here is an example call and configuration, where *image* is your Image+ TV:
 
 **Chunk tplBlogIntroImg**
 
-```
+``` html
 <div class="feature" style="margin-bottom:1rem">
     <a href="[[+caption]]"><img src="[[+source.src:pthumb=`w=320`]]" alt="[[+alt]]" /></a>
 </div>
@@ -123,11 +111,11 @@ Here is an example call and configuration, where *image* is your Image+ TV:
 
 ### Responsive images
 
-If you want to display responsive images with and without the crop, you could
-use the *ImagePlus Snippet*.
+If you want to display responsive images with and without the crop, you could use the *ImagePlus Snippet*.
 
 **Snippet Call**
-```
+
+``` php
 [[ImagePlus? 
 &tvname=`yourtvname` 
 &type=`tpl` 
@@ -136,17 +124,18 @@ use the *ImagePlus Snippet*.
 &pagetitle=`[[*pagetitle]]`
 ]]
 ```
-    
+
 **Chunk tplResponsiveImage**
-```
+
+``` html
 <picture>
     <source media="(min-width: 36em)"
-            srcset="[[+source.src:pthumb=`w=1024`]] 1024w,
-                [[+source.src:pthumb=`w=640`]] 640w,
-                [[+source.src:pthumb=`w=320`]] 320w"
-            sizes="33.3vw"/>
+        srcset="[[+source.src:pthumb=`w=1024`]] 1024w,
+            [[+source.src:pthumb=`w=640`]] 640w,
+            [[+source.src:pthumb=`w=320`]] 320w"
+        sizes="33.3vw"/>
     <source srcset="[[+source.src:pthumb=`[[+crop.options]]&w=640`]] 2x,
-                [[+source.src:pthumb=`[[+crop.options]]&w=320`]] 1x"/>
+        [[+source.src:pthumb=`[[+crop.options]]&w=320`]] 1x"/>
     <img src="[[+url]]" alt="[[+alt:default=`[[+pagetitle]]`]]"/>
 </picture>
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,23 +1,13 @@
-## Creating a new Template Variable
+# Creating a new Template Variable
 
-Once Image+ is installed, you can create Template Variables [TV] in the normal
-way, but instead of setting the **Input Type** in Input Options to *Image*,
-select *Image+* instead.
+Once Image+ is installed, you can create Template Variables [TV] in the normal way, but instead of setting the **Input Type** in Input Options to *Image*, select *Image+* instead.
 
-For most use cases, you should also set the **Output Type** in Output Options to
-*Image+*. This allows you to control the image output on a resource.
+For most use cases, you should also set the **Output Type** in Output Options to *Image+*. This allows you to control the image output on a resource.
 
 ## The cropping tool
 
-When using an *Image+* TV, you could select an image exactly the same way as in
-a normal *Image* TV. Once an image is selected, a cropping window is displayed
-and you could select the area of the image to use. The original image is not
-changed and so you can upload a single image, and re-use it in several places at
-different sizes (and crops with multiple Image+ TVs) around the site.
+When using an *Image+* TV, you could select an image exactly the same way as in a normal *Image* TV. Once an image is selected, a cropping window is displayed and you could select the area of the image to use. The original image is not changed and so you can upload a single image, and re-use it in several places at different sizes (and crops with multiple Image+ TVs) around the site.
 
-If you want to change the cropping area, you have to click on the crop trigger
-of the Image+ TV.
+If you want to change the cropping area, you have to click on the crop trigger of the Image+ TV.
 
-In the cropping window you have to drag the handles of the dotted box to change
-the cropping area. If the TV was configured with size constraints or an aspect
-ratio, the crop area will be restricted to match this aspect ratio.
+In the cropping window you have to drag the handles of the dotted box to change the cropping area. If the TV was configured with size constraints or an aspect ratio, the crop area will be restricted to match this aspect ratio.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,21 +1,18 @@
 # Image+
 
 Image+ is an advanced image custom template variable type for MODx Revolution.
-The dimensions for the uploaded image can (optionally) be configured to
-constrain a minimal width and/or height. The image crop could be forced to
-remain at a pre-set ratio. A graphical tool could be used to crop the image to
-the required dimensions/proportions.
+The dimensions for the uploaded image can (optionally) be configured to constrain a minimal width and/or height. The image crop could be forced to
+remain at a pre-set ratio. A graphical tool could be used to crop the image to the required dimensions/proportions.
 
-### Requirements
+## Requirements
 
 * MODX Revolution 2.2.4+
 * PHP v5.3+
 * MODX Cropping Engine i.e. [pThumb](https://modx.com/extras/package/pthumb)
 
-### Features
+## Features
 
 * Visual Image cropping tool integrated into the MODX manager interface.
-* Option to constrain minimal width and/or height for the uploaded image. 
+* Option to constrain minimal width and/or height for the uploaded image.
 * User image crop can be forced to remain at pre-set ratio.
-* Use a chunk as an output template and fill placeholders with url, height, width, alt-tag, phpthumb options etc of the 
-  cropped uploaded image.
+* Use a chunk as an output template and fill placeholders with url, height, width, alt-tag, phpthumb options etc of the cropped uploaded image.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,12 +1,10 @@
-## Install from MODX Extras
+# Install from MODX Extras
 
-Search for Image+ in the Package Manager of your MODX installation and install
-it in there.
+Search for Image+ in the Package Manager of your MODX installation and install it in there.
 
 ## Manual installation
 
-If you can't access the MODX Extras Repository in your MODX installation, you
-can manually install Image+.
+If you can't access the MODX Extras Repository in your MODX installation, you can manually install Image+.
 
 * Download the transport package from [MODX Extras](https://modx.com/extras/package/imageplustvinput) (or one of the pre built transport packages in [_packages](https://github.com/Jako/ImagePlus/tree/master/_packages))
 * Upload the zip file to your MODX installation's `core/packages` folder or upload it manually in the MODX Package Manager.
@@ -15,9 +13,6 @@ can manually install Image+.
 
 ## Build it from source
 
-To build and install the package from source you could use [Git Package
-Management](https://github.com/TheBoxer/Git-Package-Management). The GitHub
-repository of Image+ contains a
-[config.json](https://github.com/Jako/ImagePlus/blob/master/_build/config.json)
-to build that package locally. Use this option, if you want to debug Image+
-and/or contribute bugfixes and enhancements.
+To build and install the package from source you could use [Git Package Management](https://github.com/TheBoxer/Git-Package-Management). The GitHub
+repository of Image+ contains a [config.json](https://github.com/Jako/ImagePlus/blob/master/_build/config.json)
+to build that package locally. Use this option, if you want to debug Image+ and/or contribute bugfixes and enhancements.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,80 +1,44 @@
-## Input Options
+# Input Options
 
-In *Image+* you could control the final size and aspect ratio of selected
-images. There are several extended input options available for an *Image+* TV:
+In *Image+* you could control the final size and aspect ratio of selected images. There are several extended input options available for an *Image+* TV:
 
-#### Target Height/Width
+## Target Height/Width
 
-Images can be constrained to a minimal height and/or width with **Target
-height** and **Target width**. If both values are set, the target aspect ratio
-of the output image is calculated with this values. Both fields have to be
-filled with an integer value.
+Images can be constrained to a minimal height and/or width with **Target height** and **Target width**. If both values are set, the target aspect ratio of the output image is calculated with this values. Both fields have to be filled with an integer value.
 
-#### Target Aspect Ratio
+## Target Aspect Ratio
 
-The aspect ratio for the output image could be restricted with **Target Aspect
-Ratio**. If target height and target width are set, this value is ignored and
-the calculated aspect ratio of target height and target width is used. The field
-has to be filled with a float value.
+The aspect ratio for the output image could be restricted with **Target Aspect Ratio**. If target height and target width are set, this value is ignored and the calculated aspect ratio of target height and target width is used. The field has to be filled with a float value.
 
-If you set only one value of **Target Height** or **Target Width** and leave
-empty **Target Aspect Ratio**, the size of the crop is not restricted to any
-aspect ratio.
+If you set only one value of **Target Height** or **Target Width** and leave empty **Target Aspect Ratio**, the size of the crop is not restricted to any aspect ratio.
 
-!!! note "How to calculate the aspect ratio"
-    The aspect ratio contains a float value: this value is easily acquired by
-    dividing any width of a desired aspect ratio by its corresponding height. So
-    say you want to all your crops to have the same aspect ratio as a `1600x1000`
-    image, simply divide `1600` by `1000`, resulting in `1.6`. This is your aspect
-    ratio value.
+> note "How to calculate the aspect ratio" The aspect ratio contains a float value: this value is easily acquired by dividing any width of a desired aspect ratio by its corresponding height. So say you want to all your crops to have the same aspect ratio as a `1600x1000` image, simply divide `1600` by `1000`, resulting in `1.6`. This is your aspect ratio value.
 
-#### Show Alt Tag Field
+## Show Alt Tag Field
 
-*Image+* TVs can also contain an **Alt Tag Field**, which is an additional text
-input, that is stored with each image. It could be output alongside the image
-i.e. as an alt-tag or title-tag.
+*Image+* TVs can also contain an **Alt Tag Field**, which is an additional text input, that is stored with each image. It could be output alongside the image i.e. as an alt-tag or title-tag.
 
-In order to output the alt text in a *Image+* TV placeholder, you will need to
-select an chunk in the **Output Options**. You could also use the ImagePlus
-snippet and specify a template chunk in the snippet call options. The alt text
-is filled in the placeholder `[[+alt]]` in that chunk.
+In order to output the alt text in a *Image+* TV placeholder, you will need to select an chunk in the **Output Options**. You could also use the ImagePlus snippet and specify a template chunk in the snippet call options. The alt text is filled in the placeholder `[[+alt]]` in that chunk.
 
-#### Show Caption Field
+## Show Caption Field
 
-*Image+* TVs can also contain an **Caption Field**, which is an additional text
-input, that is stored with each image. It could be output beneath the image
-i.e. in an additional caption div.
+*Image+* TVs can also contain an **Caption Field**, which is an additional text input, that is stored with each image. It could be output beneath the image i.e. in an additional caption div.
 
-In order to output the caption in a *Image+* TV placeholder, you will need to
-select an chunk in the **Output Options**. You could also use the ImagePlus
-snippet and specify a template chunk in the snippet call options. The caption is
-filled in the placeholder `[[+caption]]` in that chunk.
+In order to output the caption in a *Image+* TV placeholder, you will need to select an chunk in the **Output Options**. You could also use the ImagePlus snippet and specify a template chunk in the snippet call options. The caption is filled in the placeholder `[[+caption]]` in that chunk.
 
-#### Show Credits Field
+## Show Credits Field
 
-*Image+* TVs can also contain an **Credits Field**, which is an additional text
-input, that is stored with each image. It could be output beneath the image
-i.e. in an additional credits div.
+*Image+* TVs can also contain an **Credits Field**, which is an additional text input, that is stored with each image. It could be output beneath the image i.e. in an additional credits div.
 
-In order to output the credits in a *Image+* TV placeholder, you will need to
-select an chunk in the **Output Options**. You could also use the ImagePlus
-snippet and specify a template chunk in the snippet call options. The credits
-are filled in the placeholder `[[+credits]]` in that chunk.
+In order to output the credits in a *Image+* TV placeholder, you will need to select an chunk in the **Output Options**. You could also use the ImagePlus snippet and specify a template chunk in the snippet call options. The credits are filled in the placeholder `[[+credits]]` in that chunk.
 
-### Context/System Settings
+## Context/System Settings
 
-Each *Image+* TV **Input Option** could be superceded by a context setting or a
-system setting. And context/system settings for a single TV could be defined,
-too. 
+Each *Image+* TV **Input Option** could be superceded by a context setting or a system setting. And context/system settings for a single TV could be defined, too.
 
-There are predefined system settings in the `imageplus` namespace, that are
-empty or equal zero. If you enable one or fill it with a value, this setting
-will supercede the Input Options of all Image+ TVs. Context settings have to be
-created before usage.
+There are predefined system settings in the `imageplus` namespace, that are empty or equal zero. If you enable one or fill it with a value, this setting will supercede the Input Options of all Image+ TVs. Context settings have to be created before usage.
 
-The global context/system settings have the prefix `imageplus.` and the single
-TV context/system settings have the prefix `imageplus.{tvname}.`. `{tvname}` has
-to be replaced by the name of the template variable.
+The global context/system settings have the prefix `imageplus.` and the single TV context/system settings have the prefix `imageplus.{tvname}.`. `{tvname}` has to be replaced by the name of the template variable.
 
 The order for those settings is [^1]
 
@@ -83,26 +47,20 @@ The order for those settings is [^1]
 - context setting
 - system setting
 
-In the `imageplus.select_config` system setting, you could create predefined
-crop sizes/aspect ratios with a helper grid. To force use the predefined
-sizes/ratios, you could enable the `imageplus.force_config` system setting.
+In the `imageplus.select_config` system setting, you could create predefined crop sizes/aspect ratios with a helper grid. To force use the predefined sizes/ratios, you could enable the `imageplus.force_config` system setting.
 
 ## Output Options
 
 There are several extended output options available for of an *Image+* TV:
 
-#### Additional phpThumb Parameters
+## Additional phpThumb Parameters
 
-As default an *Image+* TV returns an relative URL to an cropped (and maybe
-constrained) image that is scaled by phpThumb. With this output option, you
-could assign several additional phpThumb parameters, that are used to generate
-the thumbnail image.
+As default an *Image+* TV returns an relative URL to an cropped (and maybe constrained) image that is scaled by phpThumb. With this output option, you could assign several additional phpThumb parameters, that are used to generate the thumbnail image.
 
-#### Output Chunk
+## Output Chunk
 
 If you select an **Output Chunk** the TV output is rendered with that chunk.
-Select the chunk name from the dropdown. Several placeholders are possible in
-that chunk to customize the output:
+Select the chunk name from the dropdown. Several placeholders are possible in that chunk to customize the output:
 
 Placeholder | Description
 ------------|------------
@@ -122,23 +80,16 @@ crop.options | Crop engine crop option string to generate the thumbnail image
 
 All these placeholders could be used in the Snippet too.
 
-#### Generate Thumb URL
+## Generate Thumb URL
 
-If you create the thumbnail in output chunk i.e. by a pthumb output filter, you
-could disable the generation of the internal thumb URL.
+If you create the thumbnail in output chunk i.e. by a pthumb output filter, you could disable the generation of the internal thumb URL.
 
-!!! caution "Caution"
-    You have to activate this option, when you don't specify an output chunk in
-    the output options or when you use the `[[+url]]` placeholder in the specified
-    output chunk. Otherwise the image is not cropped/resized and the original
-    image path is returned.
+> caution "Caution"
+> You have to activate this option, when you don't specify an output chunk in     the output options or when you use the `[[+url]]` placeholder in the specified output chunk. Otherwise the image is not cropped/resized and the original image path is returned.
 
 ## Snippet
 
-The Snippet gives you a second option to render the TV value. With the template
-variable output, you are restricted to one output chunk per template variable,
-with the snippet you could be more flexiple use different output chunks. The
-following properties could be set in the snippet call:
+The Snippet gives you a second option to render the TV value. With the template variable output, you are restricted to one output chunk per template variable, with the snippet you could be more flexiple use different output chunks. The following properties could be set in the snippet call:
 
 Property | Description | Default
 ---------|-------------|--------
@@ -150,9 +101,9 @@ tpl | Template chunk for the snippet output [^6]. | ImagePlus.image
 value | Use your own JSON encoded value for the snippet output. The properties `tvname` and `docid` are ignored. | -
 debug | Log debug informations in MODX error log. | 0 (No)
 
-#### Example
+## Example
 
-```
+``` php
 [[ImagePlus?
 &tvname=`imageplus`
 &docid=`1`
@@ -162,9 +113,7 @@ debug | Log debug informations in MODX error log. | 0 (No)
 ]]
 ```
 
-This snippet call outputs the content of the template variable with the name
-`imageplus` of resource `1` and the extended phpThumb option `&w=100` (width:
-100px) in the parsed `ImagePlus.demo` chunk.
+This snippet call outputs the content of the template variable with the name `imageplus` of resource `1` and the extended phpThumb option `&w=100` (width: 100px) in the parsed `ImagePlus.demo` chunk.
 
 [^1]: The first entry supercedes the second entry in the list etc.
 [^2]: Outputs *image* if the Image+ TV contains an image, otherwise *noimage*.


### PR DESCRIPTION
Updating markdown markup, via markdown linter rules

https://github.com/modxcms/revolution/issues/15439 

The parser generates incorrect markup, since there must be an empty line after the lists, code, headers