### PR TITLE
Fix PHP warning: Undefined array key 'targetHeight' + 'targetWidth'

### DIFF
--- a/core/components/imageplus/src/ImagePlus.php
+++ b/core/components/imageplus/src/ImagePlus.php
@@ -293,8 +293,8 @@ class ImagePlus
                         'source' => $source->get('id'),
                         'src' => $json
                     ],
-                    'targetHeight' => (int)$opts['targetHeight'],
-                    'targetWidth' => (int)$opts['targetWidth']
+                    'targetHeight' => (int)($opts['targetHeight'] ?? 0),
+                    'targetWidth' => (int)($opts['targetWidth'] ?? 0)
                 ]);
             }
         }


### PR DESCRIPTION
Fix warnings in PHP 8.x