### PR TITLE
AWS Sources

### DIFF
--- a/source/js/mgr/imageplus.panel.input.js
+++ b/source/js/mgr/imageplus.panel.input.js
@@ -359,7 +359,8 @@ Ext.extend(ImagePlus.panel.input, MODx.Panel, {
                 return false;
             }
         })(this);
-        img.src = baseUrl + this.image.sourceImg.src;
+        srcTrim = this.image.sourceImg.src.replace(new RegExp('^(' + baseUrl + ')+'), '');
+        img.src = baseUrl + srcTrim;
     },
     // Update the component display on state change
     updateDisplay: function () {


### PR DESCRIPTION
I've added a trim statement to the URL to help with external image sources. These return with the base URL prepended when grabbed from the media browser.